### PR TITLE
Fix for mysql 8.x

### DIFF
--- a/WebContent/wavsep-install/install.jsp
+++ b/WebContent/wavsep-install/install.jsp
@@ -167,7 +167,7 @@ if (request.getParameter("username") == null
 	    	
 		    String rootConnectionString =
         	    "jdbc:mysql://" + host + ":" + port +
-        	    "/information_schema?user=" + username + "&password=" + password;
+        	    "/mysql?characterEncoding=utf8&user=" + username + "&password=" + password;
 		
 		    /* Load the MySQL driver */
 	        String driver = DatabaseConstants.DATABASE_DRIVER;
@@ -209,7 +209,7 @@ if (request.getParameter("username") == null
 		 	rootConnectionString =
         	    "jdbc:mysql://" + host + ":" + port +
         	    "/" + wavsepDB + 
-        	    "?user=" + username + "&password=" + password;
+        	    "?characterEncoding=utf8&user=" + username + "&password=" + password;
 		
 		 	/* Load the MySQL driver */
 	        driver = DatabaseConstants.DATABASE_DRIVER;


### PR DESCRIPTION
Fix the use of mysql server 8.x since the default characterEncoding is incompatible with the script.
Also, by default, root has no privileges on information_schema so the testing connexion should be on the mysql default table.